### PR TITLE
Support running on macOS 12

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -27,6 +27,12 @@ opts=( [gawk]="-pdemo.prof" )
 declare -A incs
 incs=( [gawk]="-flib/hex.gawk" [gawk500]="-flib/hex.gawk" [gawk511]="-flib/hex.gawk" [mawk]="-flib/hex.awk" [mawk133]="-flib/hex.awk" [nawk]="-flib/hex.awk" [awk]="-flib/hex.awk" [bbawk]="-flib/hex.awk" )
 
+case $(uname) in
+  Linux) inc_timex="-flib/time-linux.awk" ;;
+  Darwin) inc_timex="-flib/time-darwin.awk" ;;
+esac
+echo "using $inc_timex as the timer"
+
 ## find all effects to include
 effects=( effects/*.awk )
 if [[ ${#effects[@]} -eq 0 ]]; then
@@ -39,4 +45,4 @@ fi
 printf "\033[?25l\033[?1049h"
 
 # start program
-LC_NUMERIC=C "$awkbin" ${opts[$awkshort]} -v debug="${debug:-0}" -v fps="${fps:-30}" -v mp3player="${mp3bin:-false}" "${effects[@]/#/-f}" ${incs[$awkshort]} -f lib/xpm3.awk -f lib/glib.awk -f demo.awk
+LC_NUMERIC=C "$awkbin" ${opts[$awkshort]} -v debug="${debug:-0}" -v fps="${fps:-30}" -v mp3player="${mp3bin:-false}" "${effects[@]/#/-f}" $inc_timex ${incs[$awkshort]} -f lib/xpm3.awk -f lib/glib.awk -f demo.awk

--- a/lib/glib.awk
+++ b/lib/glib.awk
@@ -10,13 +10,6 @@ BEGIN {
 
 function clamp(val, a, b) { return (val<a) ? a : (val>b) ? b : val }
 
-## get timestamp with one-hundreth of a second precision
-function timex() {
-  getline <"/proc/uptime"
-  close("/proc/uptime")
-  return $1
-}
-
 function clear(dst) { fill(dst, "0;0;0") }
 
 function blend(a, b, alpha1, alpha2,    fg, bg, r, y,z) {

--- a/lib/time-darwin.awk
+++ b/lib/time-darwin.awk
@@ -1,0 +1,6 @@
+## get timestamp with one-hundreth of a second precision
+function timex() {
+  "sysctl -n machdep.time_since_reset" | getline
+  close("sysctl -n machdep.time_since_reset")
+  return $1/24000000
+}

--- a/lib/time-linux.awk
+++ b/lib/time-linux.awk
@@ -1,0 +1,7 @@
+## get timestamp with one-hundreth of a second precision
+function timex() {
+  getline <"/proc/uptime"
+  close("/proc/uptime")
+  return $1
+}
+


### PR DESCRIPTION
Alas, macOS doesn't have `/proc/uptime` to give a handy
"centiseconds" counter. Some twiddling and investigation
suggests that the `machdep.time_since_reset` sysctl is an
incrementing counter (albeit at a slightly odd 24MHz) that
measures the passing of time.

Since it's easier for the shell script launcher to find the OS,
move `timex()` into an include file (`lib/time-linux.awk`,
`lib/time-darwin.awk`) and add the correct one to the invocation.

(Annoyingly, this only seems to exist in macOS 12.  Or at least
it's not in 11.6.4.  But it's better than nothing...)