### PR TITLE
Make hex() function portable across AWKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Dependencies:
     - mawk (1.3.3 and 1.3.4)
     - gawk (all versions from 4.1.4 till 5.1.1)
     - nawk (20121220)
+    - goawk (v1.18.0)
     - (!) busybox awk technically works, but the performance I got was horrible
   - If you want music to accompany the visual effects, one of the following:
     - ffplay (part of ffmpeg)

--- a/demo.sh
+++ b/demo.sh
@@ -6,7 +6,7 @@ cleanup() { printf "\033[?25h\033[?1049l"; }
 trap cleanup EXIT
 
 ## find suitable awk version
-for awkshort in ${awk:-mawk gawk nawk awk}; do
+for awkshort in ${awk:-mawk gawk nawk awk goawk}; do
   awkbin=$(type -P "$awkshort") && break
 done
 if [[ -z "$awkbin" ]]; then
@@ -23,10 +23,6 @@ done
 declare -A opts
 opts=( [gawk]="-pdemo.prof" )
 
-## add specific awk includes here
-declare -A incs
-incs=( [gawk]="-flib/hex.gawk" [gawk500]="-flib/hex.gawk" [gawk511]="-flib/hex.gawk" [mawk]="-flib/hex.awk" [mawk133]="-flib/hex.awk" [nawk]="-flib/hex.awk" [awk]="-flib/hex.awk" [bbawk]="-flib/hex.awk" )
-
 ## find all effects to include
 effects=( effects/*.awk )
 if [[ ${#effects[@]} -eq 0 ]]; then
@@ -39,4 +35,4 @@ fi
 printf "\033[?25l\033[?1049h"
 
 # start program
-LC_NUMERIC=C "$awkbin" ${opts[$awkshort]} -v debug="${debug:-0}" -v fps="${fps:-30}" -v mp3player="${mp3bin:-false}" "${effects[@]/#/-f}" ${incs[$awkshort]} -f lib/xpm3.awk -f lib/glib.awk -f demo.awk
+LC_NUMERIC=C "$awkbin" ${opts[$awkshort]} -v debug="${debug:-0}" -v fps="${fps:-30}" -v mp3player="${mp3bin:-false}" "${effects[@]/#/-f}" -f lib/xpm3.awk -f lib/glib.awk -f demo.awk

--- a/lib/hex.awk
+++ b/lib/hex.awk
@@ -1,1 +1,0 @@
-function hex(str) { return int(str) }

--- a/lib/hex.gawk
+++ b/lib/hex.gawk
@@ -1,1 +1,0 @@
-function hex(str) { return strtonum(str) }

--- a/lib/xpm3.awk
+++ b/lib/xpm3.awk
@@ -9,6 +9,8 @@ BEGIN {
       pallet[$1] = sprintf("%d;%d;%d", arr[1], arr[2], arr[3])
     }
   close(cmd)
+
+  hexdigits = "0123456789abcdef"
 }
 
 function xpm3load(fname, dst,    a, width, height, numcols, charsppx, color, c, data, i, j, line, pix) {
@@ -77,4 +79,21 @@ function xpm3load(fname, dst,    a, width, height, numcols, charsppx, color, c, 
   dst["height"] = height
 
   return 1
+}
+
+# Convert string of hex digits (optionally prefixed with "0x") to number.
+function hex(str,    n, i, digit) {
+  str = tolower(str)
+  if (substr(str, 1, 1) == "-")
+    return -hex(substr(str, 2))
+  if (substr(str, 1, 2) == "0x")
+    str = substr(str, 3)
+  n = 0
+  for (i=1; i<=length(str); i++) {
+    digit = index(hexdigits, substr(str, i, 1))
+    if (digit == 0)
+      return n
+    n = n*16 + digit-1
+  }
+  return n
 }


### PR DESCRIPTION
Hi @patsie75, as author of [GoAWK](https://github.com/benhoyt/goawk) and ex-demoscener, this is an amazing little project -- kudos!

I tried your demo using the latest version of GoAWK, and all of it worked except the scroller. I narrowed it down to the font loading, specifically the `hex()` function, which depends on non-POSIX behavior of `int()` parsing strings prefixed with `0x` as hex. I see that gawk (without `-n` or `-P`) doesn't support this either, so you were using `strtonum()` there. It seems better just to write our own portable version of `hex()` and avoid the `lib/hex.awk` / `lib/hex.gawk` variants.

I'm open to other suggestions instead if you'd prefer. I'm also thinking of adding the auto-`0x` parsing to GoAWK's `int()` behaviour. Though I'm leaning towards not doing that as Gawk (by far the most commonly-used AWK now) seems to have avoided it.

This PR makes that change, and additionally adds `goawk` to the list of supported/tested versions.